### PR TITLE
Added URLImageCache and URLFileDownloader to load images.

### DIFF
--- a/Classes/ios/SCVURLDownloader.h
+++ b/Classes/ios/SCVURLDownloader.h
@@ -1,0 +1,30 @@
+//
+//  SCVURLDownloader.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SCVURLDownloader;
+
+@protocol SCVURLDowloaderObserver
+
+- (void)urlDownloader:(SCVURLDownloader *)downloader didDownloadFileWithURL:(NSURL *)url data:(NSData *)data;
+- (void)urlDownloader:(SCVURLDownloader *)downloader didFailedDownloadingFileWithURL:(NSURL *)url error:(NSError *)error;
+
+@end
+
+@interface SCVURLDownloader : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)downloadFileWithURL:(NSURL *)url observer:(id<SCVURLDowloaderObserver>)observer;
+- (void)cancelDownloadWithURL:(NSURL *)url;
+- (void)cancelDownloadsWithObserver:(id<SCVURLDowloaderObserver>)observer;
+
+@property (nonatomic, assign) NSUInteger maxConnections;
+
+@end

--- a/Classes/ios/SCVURLDownloader.m
+++ b/Classes/ios/SCVURLDownloader.m
@@ -1,0 +1,160 @@
+//
+//  SCVURLDownloader.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "SCVURLDownloader.h"
+
+@interface SCVURLDownloader()
+
+@property (nonatomic, strong) NSMutableDictionary *observers; // key URL, value observers array
+@property (nonatomic, strong) NSMutableDictionary *connections; // key url, value connection
+@property (nonatomic, strong) NSMutableDictionary *connectionsData; // key url, value mutable data
+@property (nonatomic, strong) NSMutableArray *runningConnections;
+@property (nonatomic, strong) NSMutableArray *queuedConnections;
+
+@end
+
+@implementation SCVURLDownloader
+
++ (instancetype)sharedInstance
+{
+    static SCVURLDownloader *_sharedInstance = nil;
+    if (!_sharedInstance) {
+        _sharedInstance = [[self alloc] init];
+    }
+    return _sharedInstance;
+}
+
+- (id)init
+{
+    if ((self = [super init])) {
+        self.observers = [NSMutableDictionary dictionary];
+        self.connections = [NSMutableDictionary dictionary];
+        self.connectionsData = [NSMutableDictionary dictionary];
+        self.maxConnections = 10;
+        self.runningConnections = [NSMutableArray array];
+        self.queuedConnections = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)downloadFileWithURL:(NSURL *)url observer:(id<SCVURLDowloaderObserver>)observer
+{
+    BOOL startNewConnection = NO;
+    if (!self.observers[url]) {
+        self.observers[url] = [NSMutableArray array];
+        startNewConnection = YES;
+    }
+    [self.observers[url] addObject:observer];
+    if (startNewConnection) {
+        [self startNewConnectionForURL:url];
+    }
+}
+
+- (void)cancelDownloadWithURL:(NSURL *)url
+{
+    NSURLConnection *connection = self.connections[url];
+    [connection cancel];
+    [self finishConnectionForURL:url withError:nil];
+}
+
+- (void)cancelDownloadsWithObserver:(id<SCVURLDowloaderObserver>)observer
+{
+    NSMutableArray *canceledUrls = [NSMutableArray array];
+    for (NSURL *url in self.observers) {
+        NSMutableArray *observers = self.observers[url];
+        [observers removeObject:observer];
+        if ([observers count] == 0) {
+            [canceledUrls addObject:url];
+        }
+    }
+    for (NSURL *url in canceledUrls) {
+        [self cancelDownloadWithURL:url];
+    }
+}
+
+- (void)startNewConnectionForURL:(NSURL *)url
+{
+    NSURLRequest *urlRequest = [NSURLRequest requestWithURL:url];
+    NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:urlRequest delegate:self startImmediately:NO];
+    if (connection) {
+        self.connections[url] = connection;
+        [self.queuedConnections addObject:connection];
+        [self startQueuedConnectionIfRequired];
+    }
+    else {
+        [self finishConnectionForURL:url withError:nil];
+    }
+}
+
+- (void)startQueuedConnectionIfRequired
+{
+    if ([self.runningConnections count] < self.maxConnections && [self.queuedConnections count] > 0) {
+        NSURLConnection *connection = self.queuedConnections[0];
+        [self.queuedConnections removeObject:connection];
+        [self.runningConnections addObject:connection];
+        [connection start];
+    }
+}
+
+- (void)finishConnectionForURL:(NSURL *)url withData:(NSData *)data
+{
+    NSArray *observers = self.observers[url];
+    for (id<SCVURLDowloaderObserver> observer in observers) {
+        [observer urlDownloader:self didDownloadFileWithURL:url data:data];
+    }
+    [self clearObjectsForURL:url];
+    [self startQueuedConnectionIfRequired];
+}
+
+- (void)finishConnectionForURL:(NSURL *)url withError:(NSError *)error
+{
+    NSArray *observers = self.observers[url];
+    for (id<SCVURLDowloaderObserver> observer in observers) {
+        [observer urlDownloader:self didFailedDownloadingFileWithURL:url error:error];
+    }
+    [self clearObjectsForURL:url];
+    [self startQueuedConnectionIfRequired];
+}
+
+- (void)clearObjectsForURL:(NSURL *)url
+{
+    NSConnection *connection = self.connections[url];
+    [self.connections removeObjectForKey:url];
+    [self.connectionsData removeObjectForKey:url];
+    [self.runningConnections removeObject:connection];
+    [self.queuedConnections removeObject:connection];
+    [self.observers removeObjectForKey:url];
+}
+
+#pragma mark - NSURLConnectionDelegate
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
+{
+    NSURL *url = [self.connections allKeysForObject:connection][0];
+    self.connectionsData[url] = [[NSMutableData alloc] init];
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
+{
+    NSURL *url = [self.connections allKeysForObject:connection][0];
+    [self.connectionsData[url] appendData:data];
+}
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
+{
+    NSURL *url = [self.connections allKeysForObject:connection][0];
+    [self finishConnectionForURL:url withError:error];
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection
+{
+    NSURL *url = [self.connections allKeysForObject:connection][0];
+    [self finishConnectionForURL:url withData:self.connectionsData[url]];
+}
+
+@end

--- a/Classes/ios/SCVURLImageCache.h
+++ b/Classes/ios/SCVURLImageCache.h
@@ -1,0 +1,20 @@
+//
+//  SCVURLImageCache.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SCVURLImageCache : NSObject
+
++ (instancetype)sharedInstance;
+
+- (UIImage *)cachedImageForURL:(NSURL *)url;
+- (void)setCachedImage:(UIImage *)image forURL:(NSURL *)url;
+- (void)removeCachedImageForURL:(NSURL *)url;
+- (void)removeCachedImagesOlderThan:(NSDate *)date;
+
+@end

--- a/Classes/ios/SCVURLImageCache.m
+++ b/Classes/ios/SCVURLImageCache.m
@@ -1,0 +1,205 @@
+//
+//  SCVURLImageCache.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "SCVURLImageCache.h"
+#import <sqlite3.h>
+
+#define BASE_FOLDER @"imageCache/"
+#define DB_FILE     @"db.sqlite"
+
+@interface SCVURLImageCache () {
+    sqlite3 *_db;
+}
+
+@property (nonatomic, strong) NSString *basePath;
+@property (nonatomic, strong) NSMapTable *currentImages;
+
+@end
+
+@implementation SCVURLImageCache
+
++ (instancetype)sharedInstance
+{
+    static SCVURLImageCache *_sharedInstance = nil;
+    if (!_sharedInstance) {
+        _sharedInstance = [[self alloc] init];
+    }
+    return _sharedInstance;
+}
+
+- (instancetype)init
+{
+    if ((self = [super init])) {
+        self.basePath = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0] stringByAppendingPathComponent:BASE_FOLDER];
+        [[NSFileManager defaultManager] createDirectoryAtPath:self.basePath
+                                  withIntermediateDirectories:YES attributes:nil error:NULL];
+        [self openDatabase];
+        self.currentImages = [NSMapTable strongToWeakObjectsMapTable];
+    }
+    return self;
+}
+
+- (UIImage *)cachedImageForURL:(NSURL *)url
+{
+    BOOL exists;
+    int hash = [self hashForImageAtURL:url existsInDB:&exists];
+    UIImage *retval = [self.currentImages objectForKey:@(hash)];
+    if (!retval && exists) {
+        NSString *path = [self filenameForHash:hash];
+        retval = [UIImage imageWithContentsOfFile:path];
+        if (retval) {
+            [self.currentImages setObject:retval forKey:@(hash)];
+        }
+    }
+    if (retval) {
+        [self updateLastAccessForHash:hash date:[NSDate date]];
+    }
+    return retval;
+}
+
+- (void)setCachedImage:(UIImage *)image forURL:(NSURL *)url
+{
+    BOOL existsInDB;
+    int hash = [self hashForImageAtURL:url existsInDB:&existsInDB];
+    NSString *path = [self filenameForHash:hash];
+    NSData *data = UIImagePNGRepresentation(image);
+    [data writeToFile:path atomically:NO];
+    [self.currentImages setObject:image forKey:@(hash)];
+    if (!existsInDB) {
+        [self insertHash:hash url:[url absoluteString] date:[NSDate date]];
+    }
+}
+
+- (void)removeCachedImageForURL:(NSURL *)url
+{
+    int hash = [self hashForImageAtURL:url existsInDB:NULL];
+    NSString *path = [self filenameForHash:hash];
+    [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
+    [self.currentImages removeObjectForKey:@(hash)];
+    [self removeHash:hash];
+}
+
+- (void)removeCachedImagesOlderThan:(NSDate *)date
+{
+    [self removeImagesOlderThan:[date timeIntervalSinceReferenceDate]];
+}
+
+- (NSString *)filenameForHash:(int)hash
+{
+    NSString *filename = [NSString stringWithFormat:@"%x.png", hash];
+    return [self.basePath stringByAppendingPathComponent:filename];
+}
+
+- (int)hashForImageAtURL:(NSURL *)url existsInDB:(BOOL *)existsInDB
+{
+    int hash = [self hashForUrl:url otherHash:0];
+    __block BOOL found = NO;
+    while (!found) {
+        BOOL exists = [self getRow:hash block:^(NSString *urlString, NSDate *lastAccess) {
+            if ([[url absoluteString] isEqualToString:urlString]) {
+                found = YES;
+            }
+        }];
+        found = found || !exists;
+        if (existsInDB) {
+            *existsInDB = exists;
+        }
+    }
+    return hash;
+}
+
+- (int)hashForUrl:(NSURL *)url otherHash:(int)otherHash // to avoid collisions
+{
+    if (!otherHash) {
+        return (int)[[url absoluteString] hash];
+    }
+    return (int)[[NSString stringWithFormat:@"%@%x", [url absoluteString], otherHash] hash];
+}
+
+#pragma mark - DB
+
+- (void)openDatabase
+{
+    const char *path = [[self.basePath stringByAppendingPathComponent:DB_FILE] UTF8String];
+    sqlite3_open(path, &_db);
+    sqlite3_exec(_db, "CREATE TABLE IF NOT EXISTS Image (hash int primary key, url varchar, lastAccess double)", NULL, NULL, NULL);
+}
+
+- (BOOL)getRow:(int)hash block:(void (^)(NSString *urlString, NSDate *lastAccess))block
+{
+    const char *sql = "SELECT url, lastAccess FROM Image WHERE hash = ?";
+    sqlite3_stmt *statement;
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_int(statement, 1, hash);
+    BOOL found = NO;
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+        if (block) {
+            NSString *url = [NSString stringWithUTF8String:(char *) sqlite3_column_text(statement, 0)];
+            NSDate *lastAccess = [NSDate dateWithTimeIntervalSinceReferenceDate:sqlite3_column_double(statement, 1)];
+            block(url, lastAccess);
+        }
+        found = YES;
+    }
+    sqlite3_finalize(statement);
+    return found;
+}
+
+- (void)insertHash:(int)hash url:(NSString *)urlString date:(NSDate *)date
+{
+    const char *sql = "INSERT INTO Image (hash, url, lastAccess) VALUES (?, ?, ?)";
+    sqlite3_stmt *statement;
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_int(statement, 1, hash);
+    sqlite3_bind_text(statement, 2, [urlString UTF8String], -1, NULL);
+    sqlite3_bind_double(statement, 3, [date timeIntervalSinceReferenceDate]);
+    sqlite3_step(statement);
+    sqlite3_finalize(statement);
+}
+
+- (void)updateLastAccessForHash:(int)hash date:(NSDate *)date
+{
+    const char *sql = "UPDATE Image SET lastAccess = ? WHERE hash = ?";
+    sqlite3_stmt *statement;
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_double(statement, 1, [date timeIntervalSinceReferenceDate]);
+    sqlite3_bind_int(statement, 2, hash);
+    sqlite3_step(statement);
+    sqlite3_finalize(statement);
+}
+
+- (void)removeHash:(int)hash
+{
+    sqlite3_stmt *statement;
+    const char *sql = "DELETE FROM Image WHERE hash = ?";
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_int(statement, 1, hash);
+    sqlite3_step(statement);
+    sqlite3_finalize(statement);
+}
+
+- (void)removeImagesOlderThan:(double)date
+{
+    sqlite3_stmt *statement;
+    const char *sql = "SELECT hash FROM Image WHERE lastAccess < ?";
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_double(statement, 1, date);
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+        int hash = sqlite3_column_int(statement, 0);
+        NSString *path = [self filenameForHash:hash];
+        [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
+        [self.currentImages removeObjectForKey:@(hash)];
+    }
+    sqlite3_finalize(statement);
+    sql = "DELETE FROM Image WHERE lastAccess < ?";
+    sqlite3_prepare_v2(_db, sql, -1, &statement, NULL);
+    sqlite3_bind_double(statement, 1, date);
+    sqlite3_step(statement);
+    sqlite3_finalize(statement);
+}
+
+@end

--- a/Classes/ios/UIImageView+ImageLoader.h
+++ b/Classes/ios/UIImageView+ImageLoader.h
@@ -1,0 +1,16 @@
+//
+//  UIImageView+ImageLoader.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImageView (ImageLoader)
+
+- (void)loadImageWithURL:(NSURL *)url
+  activityIndicatorStyle:(UIActivityIndicatorViewStyle)activityIndicatorStyle;
+
+@end

--- a/Classes/ios/UIImageView+ImageLoader.m
+++ b/Classes/ios/UIImageView+ImageLoader.m
@@ -1,0 +1,69 @@
+//
+//  UIImageView+ImageLoader.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "UIImageView+ImageLoader.h"
+#import "SCVURLImageCache.h"
+#import "SCVURLDownloader.h"
+
+@interface UIImageView (URLDownloaderObserver) <SCVURLDowloaderObserver>
+
+@end
+
+@implementation UIImageView (ImageLoader)
+
+- (void)loadImageWithURL:(NSURL *)url
+  activityIndicatorStyle:(UIActivityIndicatorViewStyle)style
+{
+    [[SCVURLDownloader sharedInstance] cancelDownloadsWithObserver:self];
+    UIImage *image = [[SCVURLImageCache sharedInstance] cachedImageForURL:url];
+    self.image = image;
+    if (!image) {
+        UIActivityIndicatorView *activityIndicator = [self activityIndicator];
+        if (!activityIndicator) {
+            activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:style];
+            activityIndicator.center = CGPointMake(self.bounds.size.width / 2, self.bounds.size.height / 2);
+            [self addSubview:activityIndicator];
+        }
+        [activityIndicator startAnimating];
+        [[SCVURLDownloader sharedInstance] downloadFileWithURL:url observer:self];
+    }
+    else {
+        [[self activityIndicator] removeFromSuperview];
+    }
+}
+
+- (UIActivityIndicatorView *)activityIndicator
+{
+    UIActivityIndicatorView *activityIndicator = (id)[self.subviews lastObject];
+    if ([activityIndicator isKindOfClass:[UIActivityIndicatorView class]]) {
+        return activityIndicator;
+    }
+    return nil;
+}
+
+@end
+
+@implementation UIImageView (URLDownloaderObserver)
+
+- (void)urlDownloader:(SCVURLDownloader *)downloader didDownloadFileWithURL:(NSURL *)url data:(NSData *)data
+{
+    UIImage *image = [[SCVURLImageCache sharedInstance] cachedImageForURL:url];
+    if (!image) {
+        image = [UIImage imageWithData:data];
+        [[SCVURLImageCache sharedInstance] setCachedImage:image forURL:url];
+    }
+    self.image = image;
+    [[self activityIndicator] removeFromSuperview];
+}
+
+- (void)urlDownloader:(SCVURLDownloader *)downloader didFailedDownloadingFileWithURL:(NSURL *)url error:(NSError *)error
+{
+    [[self activityIndicator] removeFromSuperview];
+}
+
+@end

--- a/Widgetorium.xcodeproj/project.pbxproj
+++ b/Widgetorium.xcodeproj/project.pbxproj
@@ -8,6 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		00FCE9CE18DC8BCC00CD05F1 /* NSData+Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 00FCE9CD18DC8BCC00CD05F1 /* NSData+Utilities.m */; };
+		882AA0CD18EDD013006CBBCC /* SCVURLImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0CC18EDD013006CBBCC /* SCVURLImageCache.m */; };
+		882AA0D018EDD033006CBBCC /* UIImageView+ImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0CF18EDD033006CBBCC /* UIImageView+ImageLoader.m */; };
+		882AA0D218EDDC10006CBBCC /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 882AA0D118EDDC10006CBBCC /* libsqlite3.dylib */; };
+		882AA0D518EE0481006CBBCC /* SCVDemoImageLoaderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0D418EE0481006CBBCC /* SCVDemoImageLoaderViewController.m */; };
+		882AA0D718EE04A3006CBBCC /* SCVDemoImageLoaderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0D618EE04A3006CBBCC /* SCVDemoImageLoaderViewController.xib */; };
+		882AA0D918EE0570006CBBCC /* SCVDemoImageLoaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0D818EE0570006CBBCC /* SCVDemoImageLoaderCell.xib */; };
+		882AA0DC18EE1933006CBBCC /* SCVURLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0DB18EE1933006CBBCC /* SCVURLDownloader.m */; };
+		882AA0E018EE2F29006CBBCC /* demoImages.plist in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0DF18EE2F29006CBBCC /* demoImages.plist */; };
 		88DB8B9618E3670D00614664 /* UIColor+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB8B9518E3670D00614664 /* UIColor+Utils.m */; };
 		E40CEED318C8E99600B9B136 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E40CEED218C8E99600B9B136 /* Foundation.framework */; };
 		E40CEED518C8E99600B9B136 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E40CEED418C8E99600B9B136 /* CoreGraphics.framework */; };
@@ -42,6 +50,18 @@
 		00FCE9CC18DC8BCC00CD05F1 /* NSData+Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Utilities.h"; sourceTree = "<group>"; };
 		00FCE9CD18DC8BCC00CD05F1 /* NSData+Utilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Utilities.m"; sourceTree = "<group>"; };
 		00FCE9CF18DC8CD700CD05F1 /* Widgetorium.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Widgetorium.podspec; sourceTree = SOURCE_ROOT; };
+		882AA0CB18EDD013006CBBCC /* SCVURLImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCVURLImageCache.h; sourceTree = "<group>"; };
+		882AA0CC18EDD013006CBBCC /* SCVURLImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVURLImageCache.m; sourceTree = "<group>"; };
+		882AA0CE18EDD033006CBBCC /* UIImageView+ImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+ImageLoader.h"; sourceTree = "<group>"; };
+		882AA0CF18EDD033006CBBCC /* UIImageView+ImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+ImageLoader.m"; sourceTree = "<group>"; };
+		882AA0D118EDDC10006CBBCC /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
+		882AA0D318EE0481006CBBCC /* SCVDemoImageLoaderViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCVDemoImageLoaderViewController.h; sourceTree = "<group>"; };
+		882AA0D418EE0481006CBBCC /* SCVDemoImageLoaderViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVDemoImageLoaderViewController.m; sourceTree = "<group>"; };
+		882AA0D618EE04A3006CBBCC /* SCVDemoImageLoaderViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SCVDemoImageLoaderViewController.xib; sourceTree = "<group>"; };
+		882AA0D818EE0570006CBBCC /* SCVDemoImageLoaderCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SCVDemoImageLoaderCell.xib; sourceTree = "<group>"; };
+		882AA0DA18EE1933006CBBCC /* SCVURLDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCVURLDownloader.h; sourceTree = "<group>"; };
+		882AA0DB18EE1933006CBBCC /* SCVURLDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVURLDownloader.m; sourceTree = "<group>"; };
+		882AA0DF18EE2F29006CBBCC /* demoImages.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = demoImages.plist; sourceTree = "<group>"; };
 		88DB8B9418E3670D00614664 /* UIColor+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+Utils.h"; sourceTree = "<group>"; };
 		88DB8B9518E3670D00614664 /* UIColor+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+Utils.m"; sourceTree = "<group>"; };
 		E40CEECF18C8E99600B9B136 /* Widgetorium.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Widgetorium.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				882AA0D218EDDC10006CBBCC /* libsqlite3.dylib in Frameworks */,
 				E40CEED518C8E99600B9B136 /* CoreGraphics.framework in Frameworks */,
 				E40CEED718C8E99600B9B136 /* UIKit.framework in Frameworks */,
 				E40CEED318C8E99600B9B136 /* Foundation.framework in Frameworks */,
@@ -106,6 +127,19 @@
 			path = Categories/ios;
 			sourceTree = "<group>";
 		};
+		882AA0CA18EDCFD7006CBBCC /* URLImageCache */ = {
+			isa = PBXGroup;
+			children = (
+				882AA0CB18EDD013006CBBCC /* SCVURLImageCache.h */,
+				882AA0CC18EDD013006CBBCC /* SCVURLImageCache.m */,
+				882AA0DA18EE1933006CBBCC /* SCVURLDownloader.h */,
+				882AA0DB18EE1933006CBBCC /* SCVURLDownloader.m */,
+				882AA0CE18EDD033006CBBCC /* UIImageView+ImageLoader.h */,
+				882AA0CF18EDD033006CBBCC /* UIImageView+ImageLoader.m */,
+			);
+			name = URLImageCache;
+			sourceTree = "<group>";
+		};
 		E40CEEC618C8E99600B9B136 = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +165,7 @@
 		E40CEED118C8E99600B9B136 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				882AA0D118EDDC10006CBBCC /* libsqlite3.dylib */,
 				E40CEED218C8E99600B9B136 /* Foundation.framework */,
 				E40CEED418C8E99600B9B136 /* CoreGraphics.framework */,
 				E40CEED618C8E99600B9B136 /* UIKit.framework */,
@@ -184,6 +219,7 @@
 		E40CEF0118C8EA5B00B9B136 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				882AA0CA18EDCFD7006CBBCC /* URLImageCache */,
 				E40CEF0318C8EAAD00B9B136 /* SCVLoadingScreen.h */,
 				E40CEF0418C8EAAD00B9B136 /* SCVLoadingScreen.m */,
 			);
@@ -207,6 +243,11 @@
 				E40CEF1118C9055B00B9B136 /* SCVLoadingViewController.h */,
 				E40CEF1218C9055B00B9B136 /* SCVLoadingViewController.m */,
 				E40CEF1318C9055B00B9B136 /* SCVLoadingViewController.xib */,
+				882AA0D318EE0481006CBBCC /* SCVDemoImageLoaderViewController.h */,
+				882AA0D418EE0481006CBBCC /* SCVDemoImageLoaderViewController.m */,
+				882AA0D618EE04A3006CBBCC /* SCVDemoImageLoaderViewController.xib */,
+				882AA0D818EE0570006CBBCC /* SCVDemoImageLoaderCell.xib */,
+				882AA0DF18EE2F29006CBBCC /* demoImages.plist */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -287,10 +328,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				882AA0E018EE2F29006CBBCC /* demoImages.plist in Resources */,
 				E40CEF1018C901E800B9B136 /* SCVDemoTableViewController.xib in Resources */,
 				E40CEEDD18C8E99600B9B136 /* InfoPlist.strings in Resources */,
 				E40CEF1518C9055B00B9B136 /* SCVLoadingViewController.xib in Resources */,
 				E40CEEE518C8E99600B9B136 /* Images.xcassets in Resources */,
+				882AA0D918EE0570006CBBCC /* SCVDemoImageLoaderCell.xib in Resources */,
+				882AA0D718EE04A3006CBBCC /* SCVDemoImageLoaderViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -311,9 +355,13 @@
 			files = (
 				88DB8B9618E3670D00614664 /* UIColor+Utils.m in Sources */,
 				E40CEF0518C8EAAD00B9B136 /* SCVLoadingScreen.m in Sources */,
+				882AA0D018EDD033006CBBCC /* UIImageView+ImageLoader.m in Sources */,
 				E40CEEDF18C8E99600B9B136 /* main.m in Sources */,
+				882AA0CD18EDD013006CBBCC /* SCVURLImageCache.m in Sources */,
 				E40CEEE318C8E99600B9B136 /* SCVAppDelegate.m in Sources */,
 				E40CEF0F18C901E800B9B136 /* SCVDemoTableViewController.m in Sources */,
+				882AA0DC18EE1933006CBBCC /* SCVURLDownloader.m in Sources */,
+				882AA0D518EE0481006CBBCC /* SCVDemoImageLoaderViewController.m in Sources */,
 				E40CEF1418C9055B00B9B136 /* SCVLoadingViewController.m in Sources */,
 				00FCE9CE18DC8BCC00CD05F1 /* NSData+Utilities.m in Sources */,
 			);

--- a/Widgetorium/Demo/SCVDemoImageLoaderCell.xib
+++ b/Widgetorium/Demo/SCVDemoImageLoaderCell.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="NPI-mz-MGo">
+            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QpO-hX-l3R">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </imageView>
+                </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            </view>
+            <userDefinedRuntimeAttributes>
+                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                    <integer key="value" value="5"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                    <integer key="value" value="1"/>
+                </userDefinedRuntimeAttribute>
+            </userDefinedRuntimeAttributes>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Widgetorium/Demo/SCVDemoImageLoaderViewController.h
+++ b/Widgetorium/Demo/SCVDemoImageLoaderViewController.h
@@ -1,0 +1,13 @@
+//
+//  SCVDemoImageLoaderViewController.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SCVDemoImageLoaderViewController : UICollectionViewController
+
+@end

--- a/Widgetorium/Demo/SCVDemoImageLoaderViewController.m
+++ b/Widgetorium/Demo/SCVDemoImageLoaderViewController.m
@@ -1,0 +1,49 @@
+//
+//  SCVDemoImageLoaderViewController.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 03/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "SCVDemoImageLoaderViewController.h"
+#import "UIImageView+ImageLoader.h"
+#import "SCVURLImageCache.h"
+
+@interface SCVDemoImageLoaderViewController ()
+
+@property (nonatomic, strong) NSArray *urlStrings;
+
+@end
+
+@implementation SCVDemoImageLoaderViewController
+
+- (id)init {
+    return [self initWithNibName:@"SCVDemoImageLoaderViewController" bundle:nil];
+}
+
+- (void)viewDidLoad
+{
+    [[SCVURLImageCache sharedInstance] removeCachedImagesOlderThan:[NSDate dateWithTimeIntervalSinceNow:-60.]];
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"demoImages" ofType:@"plist"];
+    self.urlStrings = [NSArray arrayWithContentsOfFile:path];
+    [super viewDidLoad];
+    [self.collectionView registerNib:[UINib nibWithNibName:@"SCVDemoImageLoaderCell" bundle:nil] forCellWithReuseIdentifier:@"Cell"];
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+{
+    return 1000;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
+    UIImageView *imageView = (id)cell.contentView.subviews[0];
+    NSString *urlString = self.urlStrings[(int)(drand48() * self.urlStrings.count)];
+    NSURL *url = [NSURL URLWithString:urlString];
+    [imageView loadImageWithURL:url activityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    return cell;
+}
+
+@end

--- a/Widgetorium/Demo/SCVDemoImageLoaderViewController.xib
+++ b/Widgetorium/Demo/SCVDemoImageLoaderViewController.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SCVDemoImageLoaderViewController">
+            <connections>
+                <outlet property="view" destination="zIh-de-j4p" id="lxI-DR-jVB"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="none" id="zIh-de-j4p">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="6" minimumInteritemSpacing="6" id="oJ6-Va-9Hf">
+                <size key="itemSize" width="100" height="100"/>
+                <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                <inset key="sectionInset" minX="4" minY="4" maxX="4" maxY="4"/>
+            </collectionViewFlowLayout>
+            <cells/>
+            <connections>
+                <outlet property="dataSource" destination="-1" id="AGM-P5-0B8"/>
+                <outlet property="delegate" destination="-1" id="poT-NP-6ah"/>
+            </connections>
+        </collectionView>
+    </objects>
+</document>

--- a/Widgetorium/Demo/SCVDemoTableViewController.m
+++ b/Widgetorium/Demo/SCVDemoTableViewController.m
@@ -8,18 +8,24 @@
 
 #import "SCVDemoTableViewController.h"
 #import "SCVLoadingViewController.h"
+#import "SCVDemoImageLoaderViewController.h"
 
 @interface SCVDemoTableViewController ()
+
+@property (nonatomic, strong) NSDictionary *cellsInfo;
 
 @end
 
 @implementation SCVDemoTableViewController
 
-- (id)initWithStyle:(UITableViewStyle)style
+- (id)init
 {
-    self = [super initWithStyle:style];
+    self = [super init];
     if (self) {
-        // Custom initialization
+        self.cellsInfo = @{
+            @"Loading View": [SCVLoadingViewController class],
+            @"Image Loader": [SCVDemoImageLoaderViewController class]
+        };
     }
     return self;
 }
@@ -52,7 +58,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 1;
+    return [self.cellsInfo count];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -63,7 +69,7 @@
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
     
-    cell.textLabel.text = @"Loading view";
+    cell.textLabel.text = [self.cellsInfo allKeys][indexPath.row];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     
     return cell;
@@ -114,7 +120,8 @@
 // In a xib-based application, navigation from a table can be handled in -tableView:didSelectRowAtIndexPath:
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UIViewController *vc = [SCVLoadingViewController new];
+    Class class = self.cellsInfo[[self.cellsInfo allKeys][indexPath.row]];
+    UIViewController *vc = [class new];
     vc.title = [tableView cellForRowAtIndexPath:indexPath].textLabel.text;
 
     [self.navigationController pushViewController:vc animated:YES];

--- a/Widgetorium/Demo/demoImages.plist
+++ b/Widgetorium/Demo/demoImages.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>http://3.bp.blogspot.com/-_ZPVJla_TBY/UDL1ggVbtQI/AAAAAAAAHbs/nWw7BEG9Q4o/s640/014+-+the+simpsons,+homero+-+wallpapers-+hd-+poster.jpg</string>
+	<string>http://img2.wikia.nocookie.net/__cb20090415001251/lossimpson/es/images/3/33/Marge_Simpson2.png</string>
+	<string>http://www.sangrefria.com/blog/images/2005/09/homer-simpson.jpg</string>
+	<string>http://upload.wikimedia.org/wikipedia/en/a/aa/Bart_Simpson_200px.png</string>
+	<string>http://img2.wikia.nocookie.net/__cb20090615084115/simpsons/images/3/3a/Seymour_Skinner.png</string>
+	<string>http://2.bp.blogspot.com/_ZTw7X_vxZ_M/Ss0e6m48l-I/AAAAAAAAEk4/VnoZg9Uke_Q/s400/Simpson+pensando.jpg</string>
+	<string>http://www.lossimpsons.comuv.com/imagenes/celebrity-image-simpsons---bart-simpson-72600.jpg</string>
+	<string>http://www.selfstoragefinders.com/blog/wp-content/uploads/2013/11/maggie.jpg</string>
+	<string>http://img2.wikia.nocookie.net/__cb20080229211101/lossimpson/es/images/4/4c/Maggie.gif</string>
+	<string>http://2.bp.blogspot.com/-x20VSciNEqk/UBLWLPggXSI/AAAAAAAADDs/KVr8JP_Pa64/s640/Simpsons18.jpg</string>
+	<string>http://1.bp.blogspot.com/_7BYfC82_vGY/S1OwsSiOCTI/AAAAAAAAAF8/KsnK5EEtARI/s320/BartSimpson11.gif</string>
+	<string>http://www.simpsoncrazy.com/content/pictures/lisa/LisaSimpson3.gif</string>
+</array>
+</plist>


### PR DESCRIPTION
Three main objects:
- SCVURLImageCache: An image cache where the URL is the key. The keys and last access for each image are stored in a sqlite3 db, allowing to remove old images. All files are stores in the cache directory, allowing the OS to delete the files if it requires space and avoiding to back the images up in the device's back up.
- SCVURLDownloader: A simple URL downloader. It allows to download asynchronously an URL located file. If there is more than one request for the same file, it uses a single connection. The connections are cancelled if the requester doesn't need it anymore. It handles a queue to avoid too many simultaneous connections.
- UIImage (ImageLoader): Uses the cached image if available. If not it start a URL download and stores it in the cache once it finishes. Shows an activity indicator while downloading the image.

And the demo in the demo app.
![captura de pantalla de simulador ios 04 04 2014 10 55 15](https://cloud.githubusercontent.com/assets/1740375/2615964/d884b51e-bc00-11e3-9807-785f3474a192.png)

And the demo in the demo app.
