### PR TITLE
Added model population.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ DerivedData
 
 #CocoaPods
 Pods
+Widgetorium.xcworkspace
+

--- a/Classes/ios/NSObject+SCVModel.h
+++ b/Classes/ios/NSObject+SCVModel.h
@@ -1,0 +1,13 @@
+//
+//  NSObject+SCVModel.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 04/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "SCVModel.h"
+
+@interface NSObject (SCVModel) <SCVModel>
+
+@end

--- a/Classes/ios/NSObject+SCVModel.m
+++ b/Classes/ios/NSObject+SCVModel.m
@@ -1,0 +1,271 @@
+//
+//  NSObject+SCVModel.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 04/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import "NSObject+SCVModel.h"
+#import <NSObjectProperties/NSObject+Properties.h>
+
+@implementation NSObject (SCVModel)
+
+- (BOOL)populateWithDictionary:(NSDictionary *)dictionary options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    // use autopopulate if it's not overriden
+    if ([[self class] instanceMethodForSelector:_cmd]
+        == [NSObject instanceMethodForSelector:_cmd]) {
+        return [self autopopulateWithDictionary:dictionary options:options error:error];
+    }
+    else if (error) {
+        *error = nil;
+    }
+    return NO;
+}
+
+- (BOOL)autopopulateWithDictionary:(NSDictionary *)dictionary options:(NSDictionary *)options error:(NSError *__autoreleasing *)returnError
+{
+    NSError *error;
+	NSArray* keys = [dictionary allKeys];
+	for (NSString *theKey in keys) {
+		id value = [dictionary valueForKey:theKey];
+        NSString *key = [self keyForDictionaryKey:theKey];
+		SEL selector = [self setterForKey:key];
+		if (selector) {
+            NSMethodSignature* signature = [self methodSignatureForSelector:selector];
+            NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:signature];
+            [invocation setTarget:self];
+            [invocation setSelector:selector];
+            switch ([self typeForSignature:signature]) {
+                case SCVModelPropertyTypeBool: {
+                    BOOL str = [[self numberWithValue:value forKey:key] boolValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeInt: {
+                    int str = [[self numberWithValue:value forKey:key] intValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeLong: {
+                    unsigned long long str = [[self numberWithValue:value forKey:key] longValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeUnsignedLong: {
+                    long long str = [[self numberWithValue:value forKey:key] longLongValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeFloat: {
+                    float str = [[self numberWithValue:value forKey:key] floatValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeDouble: {
+                    double str = [[self numberWithValue:value forKey:key] doubleValue];
+                    [invocation setArgument:&str atIndex:2];
+                    break;
+                }
+                case SCVModelPropertyTypeObject: {
+                    id obj = value;
+                    if (![obj isKindOfClass:[NSNull class]]) {
+                        Class clazz = [self classTypeForKey:key options:options error:&error];
+                        obj = [self populatedObjectForKey:key class:clazz object:obj options:options error:&error];
+                        [invocation setArgument:&obj atIndex:2];
+                    }
+                    else {
+                        // do not set null values
+                        continue;
+                    }
+                }
+            }
+			[invocation invoke];
+		}
+		else {
+ 			NSLog(@"%s does not have a property named %@", class_getName([self class]), key);
+		}
+	}
+    if (returnError) {
+        *returnError = error;
+    }
+    return !error;
+}
+
+- (NSString *)keyForDictionaryKey:(NSString *)key
+{
+    if (![[self class] hasPropertyNamed:key]) {
+        key = [NSString stringWithFormat:@"%@%@", [[key substringToIndex:1] lowercaseString], [key substringFromIndex:1]];
+    }
+    return key;
+}
+
+- (SEL)setterForKey:(NSString *)key
+{
+    return [[self class] setterForKey:key];
+}
+
++ (SEL)setterForKey:(NSString *)name
+{
+	objc_property_t property = class_getProperty( self, [name UTF8String] );
+	if (!property) {
+		return NULL;
+    }
+	SEL result = property_getSetter(property);
+	if (result) {
+		return result;
+	}
+	// build a setter name
+	NSMutableString *str = [NSMutableString stringWithString:@"set"];
+	[str appendString:[[name substringToIndex:1] uppercaseString]];
+	if ([name length] > 1)
+		[str appendString: [name substringFromIndex: 1]];
+    [str appendString:@":"];
+	result = NSSelectorFromString(str);
+	if (![self instancesRespondToSelector:result]) {
+		[NSException raise: NSInternalInconsistencyException
+					format: @"%@ has property '%@' with no custom setter, but does not respond to the default setter",
+		 self, str];
+	}
+	return result;
+}
+
+- (SCVModelPropertyType)typeForSignature:(NSMethodSignature *)signature
+{
+    const char *type = [signature getArgumentTypeAtIndex:2];
+    if (strcmp(type,@encode(int)) == 0) {
+        return SCVModelPropertyTypeInt;
+    }
+    else if (strcmp(type,@encode(double)) == 0) {
+        return SCVModelPropertyTypeDouble;
+    }
+    else if (strcmp(type,@encode(float)) == 0) {
+        return SCVModelPropertyTypeFloat;
+    }
+    else if (strcmp(type,@encode(unsigned long long)) == 0) {
+        return SCVModelPropertyTypeUnsignedLong;
+    }
+    else if (strcmp(type,@encode(long long)) == 0) {
+        return SCVModelPropertyTypeLong;
+    }
+    else if (strcmp(type, @encode(BOOL)) == 0) {
+        return SCVModelPropertyTypeBool;
+    }
+    return SCVModelPropertyTypeObject;
+}
+
+- (Class)classForArrayPropertyWithKey:(NSString *)key options:(NSDictionary *)options error:(NSError **)error
+{
+    @throw [NSException exceptionWithName:@"SCV.ModelAutopopulateCouldNotResolveClass" reason:[NSString stringWithFormat:@"Model autopopulate could not resolve class name for items in property array %@", key] userInfo:nil];
+}
+
+- (NSDate *)dateFromString:(NSString *)dateString key:(NSString *)key options:(NSDictionary *)options error:(NSError **)error
+{
+    @throw [NSException exceptionWithName:@"SCV.ModelAutopopulateCouldNotParseDate" reason:[NSString stringWithFormat:@"Model autopopulate could not parse date for property %@", key] userInfo:nil];
+}
+
+#pragma mark - convert values for key
+
+- (NSNumber *)numberWithValue:(id)value forKey:(NSString *)key
+{
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return value;
+    }
+    @throw [NSException exceptionWithName:@"SCV.ModelAutopopulateCouldNotParseNumber" reason:[NSString stringWithFormat:@"Model autopopulate could not parse number for property %@. Override -[%@ numberValue:forKey:]", key, NSStringFromClass([self class])] userInfo:nil];
+}
+
+- (id)populatedObjectForKey:(NSString *)key
+                      class:(Class)clazz
+                     object:(id)object
+                    options:(NSDictionary *)options
+                      error:(NSError **)error
+{
+    return [clazz populatedObjectWithObject:object options:options error:error];
+}
+
+- (Class)classTypeForKey:(NSString *)key options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    Class clazz = [[self class] classOfPropertyNamed:key];
+    if ([clazz isSubclassOfClass:[NSArray class]]) {
+        clazz = [self classForArrayPropertyWithKey:key options:options error:error];
+    }
+    return clazz;
+}
+
+#pragma mark -
+
++ (instancetype)populatedObjectWithObject:(id)object options:(NSDictionary *)options error:(NSError **)error
+{
+    if ([object isKindOfClass:[NSArray class]]) {
+        return [self populatedObjectArrayWithArray:object options:options error:error];
+    }
+    else if ([object isKindOfClass:[NSDictionary class]]) {
+        return [self populatedObjectWithDictionary:object options:options error:error];
+    }
+    return nil;
+}
+
++ (instancetype)populatedObjectWithDictionary:(NSDictionary *)dictionary options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    id retval = [self new];
+    [retval populateWithDictionary:dictionary options:options error:error];
+    return retval;
+}
+
++ (NSArray *)populatedObjectArrayWithArray:(NSArray *)input options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    NSMutableArray *output = [NSMutableArray arrayWithCapacity:[input count]];
+    NSError *myError = nil;
+    for (id obj in input) {
+        id model = [self populatedObjectWithObject:obj options:options error:&myError];
+        if (model && !myError) {
+            [output addObject:model];
+        }
+        else if (myError) {
+            if (error) {
+                *error = myError;
+            }
+            return nil;
+        }
+    }
+    return [output copy];
+}
+
+@end
+
+@implementation NSNumber (SCVModel)
+
++ (instancetype)populatedObjectWithObject:(id)object options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    if ([object isKindOfClass:[NSNumber class]]) {
+        return object;
+    }
+    return [super populatedObjectWithObject:object options:options error:error];
+}
+
+@end
+
+@implementation NSString (SCVModel)
+
++ (instancetype)populatedObjectWithObject:(id)object options:(NSDictionary *)options error:(NSError **)error
+{
+    if ([object isKindOfClass:[NSString class]]) {
+        return object;
+    }
+    return [super populatedObjectWithObject:object options:options error:error];
+}
+
+@end
+
+@implementation NSURL (SCVModel)
+
++ (instancetype)populatedObjectWithObject:(id)object options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    if ([object isKindOfClass:[NSString class]]) {
+        return [NSURL URLWithString:object];
+    }
+    return [super populatedObjectWithObject:object options:options error:error];
+}
+
+@end

--- a/Classes/ios/SCVModel.h
+++ b/Classes/ios/SCVModel.h
@@ -1,0 +1,47 @@
+//
+//  SCVModel.h
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 04/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+    SCVModelPropertyTypeBool,
+    SCVModelPropertyTypeInt,
+    SCVModelPropertyTypeLong,
+    SCVModelPropertyTypeUnsignedLong,
+    SCVModelPropertyTypeFloat,
+    SCVModelPropertyTypeDouble,
+    SCVModelPropertyTypeObject
+} SCVModelPropertyType;
+
+@protocol SCVModel <NSObject>
+
++ (instancetype)populatedObjectWithObject:(id)object
+                                  options:(NSDictionary *)options
+                                    error:(NSError **)error;
++ (instancetype)populatedObjectWithDictionary:(NSDictionary *)dictionary
+                                      options:(NSDictionary *)options
+                                        error:(NSError **)error;
++ (NSArray *)populatedObjectArrayWithArray:(NSArray *)array
+                                      options:(NSDictionary *)options
+                                        error:(NSError **)error;
+
+/*
+ *  Override points:
+ */
+- (BOOL)populateWithDictionary:(NSDictionary *)dictionary
+                       options:(NSDictionary *)options
+                         error:(NSError **)error;
+- (Class)classForArrayPropertyWithKey:(NSString *)key
+                              options:(NSDictionary *)options
+                                error:(NSError **)error;
+- (NSDate *)dateFromString:(NSString *)dateString
+                       key:(NSString *)key
+                   options:(NSDictionary *)options
+                     error:(NSError **)error;
+
+@end

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,5 @@
+platform :ios, '6.1.3'
+xcodeproj 'Widgetorium.xcodeproj'
+
+inhibit_all_warnings!
+pod 'NSObjectProperties', '~> 0.0.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,10 @@
+PODS:
+  - NSObjectProperties (0.0.3)
+
+DEPENDENCIES:
+  - NSObjectProperties (~> 0.0.3)
+
+SPEC CHECKSUMS:
+  NSObjectProperties: 7e80ac3e4264466c62e02935a1945f6d64aff3a7
+
+COCOAPODS: 0.29.0

--- a/Widgetorium.xcodeproj/project.pbxproj
+++ b/Widgetorium.xcodeproj/project.pbxproj
@@ -16,7 +16,11 @@
 		882AA0D918EE0570006CBBCC /* SCVDemoImageLoaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0D818EE0570006CBBCC /* SCVDemoImageLoaderCell.xib */; };
 		882AA0DC18EE1933006CBBCC /* SCVURLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0DB18EE1933006CBBCC /* SCVURLDownloader.m */; };
 		882AA0E018EE2F29006CBBCC /* demoImages.plist in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0DF18EE2F29006CBBCC /* demoImages.plist */; };
+		882AA0EA18EF2A12006CBBCC /* NSObject+SCVModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0E918EF2A12006CBBCC /* NSObject+SCVModel.m */; };
+		882AA0EF18EF52F4006CBBCC /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 882AA0EE18EF52F4006CBBCC /* Podfile */; };
+		882AA0F218EF55FC006CBBCC /* SCVModelTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 882AA0F118EF55FC006CBBCC /* SCVModelTest.m */; };
 		88DB8B9618E3670D00614664 /* UIColor+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 88DB8B9518E3670D00614664 /* UIColor+Utils.m */; };
+		D3A5B3185792452CAA749C78 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EB743D22A0F421CA6DA163E /* libPods.a */; };
 		E40CEED318C8E99600B9B136 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E40CEED218C8E99600B9B136 /* Foundation.framework */; };
 		E40CEED518C8E99600B9B136 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E40CEED418C8E99600B9B136 /* CoreGraphics.framework */; };
 		E40CEED718C8E99600B9B136 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E40CEED618C8E99600B9B136 /* UIKit.framework */; };
@@ -50,6 +54,8 @@
 		00FCE9CC18DC8BCC00CD05F1 /* NSData+Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Utilities.h"; sourceTree = "<group>"; };
 		00FCE9CD18DC8BCC00CD05F1 /* NSData+Utilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Utilities.m"; sourceTree = "<group>"; };
 		00FCE9CF18DC8CD700CD05F1 /* Widgetorium.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Widgetorium.podspec; sourceTree = SOURCE_ROOT; };
+		1EB743D22A0F421CA6DA163E /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		520F1405D4B94137ADD8DEDA /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		882AA0CB18EDD013006CBBCC /* SCVURLImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCVURLImageCache.h; sourceTree = "<group>"; };
 		882AA0CC18EDD013006CBBCC /* SCVURLImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVURLImageCache.m; sourceTree = "<group>"; };
 		882AA0CE18EDD033006CBBCC /* UIImageView+ImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+ImageLoader.h"; sourceTree = "<group>"; };
@@ -62,6 +68,11 @@
 		882AA0DA18EE1933006CBBCC /* SCVURLDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCVURLDownloader.h; sourceTree = "<group>"; };
 		882AA0DB18EE1933006CBBCC /* SCVURLDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVURLDownloader.m; sourceTree = "<group>"; };
 		882AA0DF18EE2F29006CBBCC /* demoImages.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = demoImages.plist; sourceTree = "<group>"; };
+		882AA0E818EF2A12006CBBCC /* NSObject+SCVModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+SCVModel.h"; sourceTree = "<group>"; };
+		882AA0E918EF2A12006CBBCC /* NSObject+SCVModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+SCVModel.m"; sourceTree = "<group>"; };
+		882AA0EB18EF2E85006CBBCC /* SCVModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SCVModel.h; sourceTree = "<group>"; };
+		882AA0EE18EF52F4006CBBCC /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = SOURCE_ROOT; };
+		882AA0F118EF55FC006CBBCC /* SCVModelTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCVModelTest.m; sourceTree = "<group>"; };
 		88DB8B9418E3670D00614664 /* UIColor+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+Utils.h"; sourceTree = "<group>"; };
 		88DB8B9518E3670D00614664 /* UIColor+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+Utils.m"; sourceTree = "<group>"; };
 		E40CEECF18C8E99600B9B136 /* Widgetorium.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Widgetorium.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +110,7 @@
 				E40CEED518C8E99600B9B136 /* CoreGraphics.framework in Frameworks */,
 				E40CEED718C8E99600B9B136 /* UIKit.framework in Frameworks */,
 				E40CEED318C8E99600B9B136 /* Foundation.framework in Frameworks */,
+				D3A5B3185792452CAA749C78 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,6 +152,16 @@
 			name = URLImageCache;
 			sourceTree = "<group>";
 		};
+		882AA0E418EF295C006CBBCC /* Parser */ = {
+			isa = PBXGroup;
+			children = (
+				882AA0EB18EF2E85006CBBCC /* SCVModel.h */,
+				882AA0E818EF2A12006CBBCC /* NSObject+SCVModel.h */,
+				882AA0E918EF2A12006CBBCC /* NSObject+SCVModel.m */,
+			);
+			name = Parser;
+			sourceTree = "<group>";
+		};
 		E40CEEC618C8E99600B9B136 = {
 			isa = PBXGroup;
 			children = (
@@ -150,6 +172,7 @@
 				E40CEEF118C8E99600B9B136 /* WidgetoriumTests */,
 				E40CEED118C8E99600B9B136 /* Frameworks */,
 				E40CEED018C8E99600B9B136 /* Products */,
+				520F1405D4B94137ADD8DEDA /* Pods.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -170,6 +193,7 @@
 				E40CEED418C8E99600B9B136 /* CoreGraphics.framework */,
 				E40CEED618C8E99600B9B136 /* UIKit.framework */,
 				E40CEEEB18C8E99600B9B136 /* XCTest.framework */,
+				1EB743D22A0F421CA6DA163E /* libPods.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -189,6 +213,7 @@
 		E40CEED918C8E99600B9B136 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				882AA0EE18EF52F4006CBBCC /* Podfile */,
 				00FCE9CF18DC8CD700CD05F1 /* Widgetorium.podspec */,
 				E40CEEDA18C8E99600B9B136 /* Widgetorium-Info.plist */,
 				E40CEEDB18C8E99600B9B136 /* InfoPlist.strings */,
@@ -202,6 +227,7 @@
 			isa = PBXGroup;
 			children = (
 				E40CEEF718C8E99600B9B136 /* UIColorTests.m */,
+				882AA0F118EF55FC006CBBCC /* SCVModelTest.m */,
 				E40CEEF218C8E99600B9B136 /* Supporting Files */,
 			);
 			path = WidgetoriumTests;
@@ -220,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				882AA0CA18EDCFD7006CBBCC /* URLImageCache */,
+				882AA0E418EF295C006CBBCC /* Parser */,
 				E40CEF0318C8EAAD00B9B136 /* SCVLoadingScreen.h */,
 				E40CEF0418C8EAAD00B9B136 /* SCVLoadingScreen.m */,
 			);
@@ -259,9 +286,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E40CEEFB18C8E99600B9B136 /* Build configuration list for PBXNativeTarget "Widgetorium" */;
 			buildPhases = (
+				1FA67ABE06D642A68F5B70EC /* Check Pods Manifest.lock */,
 				E40CEECB18C8E99600B9B136 /* Sources */,
 				E40CEECC18C8E99600B9B136 /* Frameworks */,
 				E40CEECD18C8E99600B9B136 /* Resources */,
+				9868A4E2802349AB9EA7E2E6 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -329,6 +358,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				882AA0E018EE2F29006CBBCC /* demoImages.plist in Resources */,
+				882AA0EF18EF52F4006CBBCC /* Podfile in Resources */,
 				E40CEF1018C901E800B9B136 /* SCVDemoTableViewController.xib in Resources */,
 				E40CEEDD18C8E99600B9B136 /* InfoPlist.strings in Resources */,
 				E40CEF1518C9055B00B9B136 /* SCVLoadingViewController.xib in Resources */,
@@ -348,6 +378,39 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		1FA67ABE06D642A68F5B70EC /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		9868A4E2802349AB9EA7E2E6 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		E40CEECB18C8E99600B9B136 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -363,6 +426,7 @@
 				882AA0DC18EE1933006CBBCC /* SCVURLDownloader.m in Sources */,
 				882AA0D518EE0481006CBBCC /* SCVDemoImageLoaderViewController.m in Sources */,
 				E40CEF1418C9055B00B9B136 /* SCVLoadingViewController.m in Sources */,
+				882AA0EA18EF2A12006CBBCC /* NSObject+SCVModel.m in Sources */,
 				00FCE9CE18DC8BCC00CD05F1 /* NSData+Utilities.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -371,6 +435,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				882AA0F218EF55FC006CBBCC /* SCVModelTest.m in Sources */,
 				E40CEEF818C8E99600B9B136 /* UIColorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -481,6 +546,7 @@
 		};
 		E40CEEFC18C8E99600B9B136 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 520F1405D4B94137ADD8DEDA /* Pods.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -494,6 +560,7 @@
 		};
 		E40CEEFD18C8E99600B9B136 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 520F1405D4B94137ADD8DEDA /* Pods.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/WidgetoriumTests/SCVModelTest.m
+++ b/WidgetoriumTests/SCVModelTest.m
@@ -1,0 +1,116 @@
+//
+//  SCVModelTest.m
+//  Widgetorium
+//
+//  Created by Emanuel Andrada on 04/04/14.
+//  Copyright (c) 2014 SCVSoft. All rights reserved.
+//
+#import <XCTest/XCTest.h>
+#import "NSObject+SCVModel.h"
+
+@interface SCVModelTest : XCTestCase
+
+@end
+
+@interface TestSimpleModel : NSObject
+
+@property (nonatomic, strong) NSString *stringField;
+@property (nonatomic, assign) NSInteger intField;
+
+@end
+
+@interface TestCompositeModel : NSObject
+
+@property (nonatomic, strong) NSURL *anUrl;
+@property (nonatomic, strong) TestSimpleModel *simple;
+@property (nonatomic, strong) NSArray *array;
+
+@end
+
+typedef enum {
+    SCVTestEnumNone,
+    SCVTestEnumSomething
+} SCVTestEnum;
+
+@interface TestEnumModel : NSObject
+
+@property (nonatomic, assign) SCVTestEnum enumValue;
+
+@end
+
+@implementation TestSimpleModel
+
+@end
+
+@implementation TestCompositeModel
+
+- (Class)classForArrayPropertyWithKey:(NSString *)key options:(NSDictionary *)options error:(NSError **)error
+{
+    if ([@"array" isEqual:key]) {
+        return [NSString class];
+    }
+    return [super classForArrayPropertyWithKey:key options:options error:error];
+}
+
+@end
+
+@implementation TestEnumModel
+
+- (NSNumber *)numberWithValue:(id)value forKey:(NSString *)key
+{
+    if ([@"enumValue" isEqualToString:key]) {
+        NSDictionary *values = @{
+            @"none": @(SCVTestEnumNone),
+            @"something": @(SCVTestEnumSomething)
+        };
+        return values[value];
+    }
+    return value;
+}
+
+@end
+
+@implementation SCVModelTest
+
+- (void)testSimpleModel
+{
+    TestSimpleModel *object = [TestSimpleModel new];
+    NSDictionary *input = @{
+        @"stringField": @"stringValue",
+        @"intField": @(123456789)
+    };
+    [object populateWithDictionary:input options:nil error:NULL];
+    XCTAssertEqualObjects(object.stringField, @"stringValue", @"");
+    XCTAssertEqual(object.intField, 123456789, @"");
+}
+
+- (void)testCompositeModel
+{
+    TestCompositeModel *object = [[TestCompositeModel alloc] init];
+    NSDictionary *input = @{
+        @"anUrl": @"http://www.google.com",
+        @"simple": @{
+            @"stringField": @"stringValue",
+            @"intField": @(123456789)
+        },
+        @"array": @[@"1", @"2", @"3"]
+    };
+    [object populateWithDictionary:input options:nil error:NULL];
+    XCTAssertEqualObjects(object.anUrl, [NSURL URLWithString:@"http://www.google.com"], @"");
+    XCTAssertEqualObjects(object.simple.stringField, @"stringValue", @"");
+    XCTAssertEqual(object.simple.intField, 123456789, @"");
+    XCTAssertEqual(object.array.count, 3, @"");
+    XCTAssertEqualObjects(object.array.lastObject, @"3", @"");
+}
+
+- (void)testEnumModel
+{
+    TestEnumModel *object = [TestEnumModel new];
+    NSDictionary *input = @{
+        @"enumValue": @"something"
+    };
+    [object populateWithDictionary:input options:nil error:NULL];
+    XCTAssertEqual(object.enumValue, SCVTestEnumSomething, @"");
+}
+
+@end


### PR DESCRIPTION
I still need to make changes on this, so don't close the PR after merging.
I have to change a few things and document some others, but it's usable, so you can continue developing other stuff.
Tests are failing in 64 bits, so I have to check what's happening there.
You can find usage examples in SCVModelTest, but basically, after defining a class, you can populate it with:

``` objective-c
NSDictionary *dictionary; // a dictionary with the model data
NSError *error;
MyModelClass *modelObject = [MyModelClass populatedObjectWithObject:dictionary options:nil error:&error];
```
